### PR TITLE
Updated Readme.md, added PHP 7.1 and 7.2 to Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,15 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - 7.0
+  - 7.1
+  - 7.2
   - hhvm
   - nightly
 
 matrix:
   allow_failures:
   - php: nightly
+  - php: hhvm
 
 before_script:
   - composer self-update

--- a/Readme.md
+++ b/Readme.md
@@ -64,4 +64,5 @@ List of available providers :
 | Provider | Description |
 |---------:|-------------|
 | [European Central Bank](http://www.ecb.europa.eu/stats/exchange/eurofxref/html/index.en.html) | All currencies quoted against the euro (base currency) |
+| [My Currency](http://www.mycurrency.net) | Almost all currencies. |
 


### PR DESCRIPTION
And failure in HHVM is now allowed.